### PR TITLE
修复了 testbench_only 被硬编码和编译报错判断的 bug，完善了 README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.out
 *.asm
 __pycache__
+.vscode

--- a/README.md
+++ b/README.md
@@ -2,16 +2,61 @@
 
 [Menci/pipeline-tester](https://github.com/Menci/pipeline-tester) 的 Python 版  
 
-## 使用方法  
-对程序的修改同原版  
-**你的 testbench 的周期数应当合理，比如1000**
+## 使用方法
 
-安装 iverilog  
+### 新建一个 testbench 文件在工程目录下
+
+1. 注意修改 `TopLevel` 为你的顶层模块名
+2. 记住这个文件的路径如 `test_bench_file = dir/mips_tb.v`，其是调用 python 脚本时输入的第三个参数
+
+```iverilog
+module mips_tb;
+
+reg reset, clock;
+
+// The top level module name should be always "TopLevel"
+TopLevel topLevel(.reset(reset), .clock(clock));
+
+integer k;
+initial begin
+    // posedge clock
+
+    // Hold reset for one cycle
+    reset = 1;
+    clock = 0; #1;
+    clock = 1; #1;
+    clock = 0; #1;
+    reset = 0; #1;
+    
+    // This line is commented when testing
+    // $stop;
+
+    #1;
+    for (k = 0; k < 1000; k = k + 1) begin
+        clock = 1; #5;
+        clock = 0; #5;
+    end
+
+    // Please finish with `syscall`, finishes here may mean the clocks are not enough (really?)
+    $finish;
+end
+    
+endmodule
+```
+
+### 修改 InstructionMemory 模块读入指令的路径
+
+`$readmemh("dir/code.txt", memory);`
+
+`dir` 是上一步提到的 `testbench` 文件所在目录
+
+### 安装 iverilog  
 
 - Windows: [Icarus Verilog for Windows](https://bleyer.org/icarus/)  
 - Linux/macOS: 使用包管理器  
 
-修改 `run.json`  
+### 修改 `run.json`
+
 - iverilog_path: iverilog 路径
 - vvp_path: vvp 路径
 - test_bench_only:  
@@ -23,12 +68,16 @@
 
 ### 运行  
 
-运行测试   
+运行测试
+
 ```bash
 python main.py test test_loop_count test_bench_file
 ```
 
-仅生成测试  
+仅生成测试
+
 ```bash
 python main.py gen test_loop_count target_dir
 ```
+
+> `test_loop_count` 是一个整数，代表运行/生成几个测试样例

--- a/iverilog.py
+++ b/iverilog.py
@@ -22,13 +22,19 @@ def iverilog_compile(
         compile_files.extend([str(x) for x in pathlib.Path(cwd).rglob("*.v")])
         compile_files.extend([str(x) for x in pathlib.Path(cwd).rglob("*.sv")])
     # print(compile_files)
+    
+    if os.path.exists(os.path.join(cwd, "a.out")):
+        os.remove(os.path.join(cwd, "a.out"))
+    
     result = subprocess.run(
         [iverilog_path, *iverilog_params, *compile_files], capture_output=True, cwd=cwd
     )
 
     if len(result.stderr):
         print(result.stderr.decode("utf-8"), file=sys.stderr)
-        raise RuntimeError("Verilog compile failed")
+    
+    if not os.path.exists(os.path.join(cwd, "a.out")):
+        raise RuntimeError("Verilog compile failed")    
 
 
 def iverilog_run(

--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ def main(args: List[str]):
         loop_count = int(args[2])
         tb_file = args[3]
         
-        iverilog_compile(tb_file, False,  run_config['iverilog_path'], run_config["iverilog_params"])
+        iverilog_compile(tb_file, run_config['test_bench_only'], run_config['iverilog_path'], run_config["iverilog_params"])
 
         for i in range(loop_count):
             print(f"round {i}/{loop_count}")


### PR DESCRIPTION
1. `iverilog_compile(tb_file, False,  run_config['iverilog_path'], run_config["iverilog_params"])` 这里，`False` 应该改成 `run_config["test_bench_only"]`
2. 如果 iverilog 报 warning 或者 sorry 也会输出到 stderr，原来的报错检查就直接误判 RuntimeError 了，我改成了编译前删掉 a.out，编译后检测是否有 a.out 来判断编译有没有成功
3. 完善了一下 README.md，把必要的内容移了过来